### PR TITLE
Parameterize configuration ownership

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,12 +38,14 @@ class logstash_reporter (
   $logstash_host  = '127.0.0.1',
   $logstash_port  = 5999,
   $config_file  = '/etc/puppet/logstash.yaml',
+  $config_owner = 'puppet',
+  $config_group = 'puppet',
 ){
 
   file { $config_file:
     ensure  => file,
-    owner   => 'puppet',
-    group   => 'puppet',
+    owner   => $config_owner,
+    group   => $config_group,
     mode    => '0444',
     content => template('logstash_reporter/logstash.yaml.erb'),
   }


### PR DESCRIPTION
This commit adds class parameters for the 'owner' and 'group' properties
of the config file. This allows this module to manage the configuration
in other Puppet installations such as Puppet Enterprise.