### PR TITLE
Sanitise fields

### DIFF
--- a/lib/puppet/reports/logstash.rb
+++ b/lib/puppet/reports/logstash.rb
@@ -41,8 +41,8 @@ Puppet::Reports.register_report(:logstash) do
     event["report_format"] = self.report_format
     event["puppet_version"] = self.puppet_version
     event["status"] = self.status
-    event["start_time"] = self.logs.first.time
-    event["end_time"] = self.logs.last.time
+    event["start_time"] = self.logs.first.time.utc.iso8601
+    event["end_time"] = self.logs.last.time.utc.iso8601
     event["metrics"] = {}
     metrics.each do |k,v|
       event["metrics"][k] = {}

--- a/lib/puppet/reports/logstash.rb
+++ b/lib/puppet/reports/logstash.rb
@@ -47,7 +47,7 @@ Puppet::Reports.register_report(:logstash) do
     metrics.each do |k,v|
       event["metrics"][k] = {}
       v.values.each do |val|
-        event["metrics"][k][val[1]] = val[2]
+        event["metrics"][k][val[1].tr('[A-Z ]', '[a-z_]')] = val[2]
       end
     end
 


### PR DESCRIPTION
This PR sanitises some of the field names as they are in title case with spaces, so for example `metrics.time.SSH authorized key` becomes `metrics.time.ssh_authorized_key`, etc.

Also, I changed the start and end timestamps to be formatted as ISO8601 to match the `@timestamp` field so they should be picked up as actual dates by Elasticsearch a bit easier.